### PR TITLE
feat: added dotenv support

### DIFF
--- a/docs/content/docs/intro.mdx
+++ b/docs/content/docs/intro.mdx
@@ -50,6 +50,8 @@ So far, we get:
 - ~React Fast Refresh~ (temporarily disabled, investigating ways to do this without babel)
 - Server-side rendering of `./pages/index`
 - Static file serving. `./public/` is mapped to `/`
+- Automatic client bundle inlining of environment variables that begin with `MWAP_`
+- `.env` support for client and server environment variables
 
 ## Related
 

--- a/packages/mwap/bin/cli.js
+++ b/packages/mwap/bin/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+const dotenv = require("dotenv");
 const sade = require("sade");
 
 const build = require("../lib/commands/build");
@@ -9,6 +10,8 @@ const start = require("../lib/commands/start");
 const pkg = require("../package.json");
 
 const prog = sade(pkg.name).version(pkg.version);
+
+dotenv.config();
 
 prog
   .command("build")

--- a/packages/mwap/lib/webpack/get-client-config.js
+++ b/packages/mwap/lib/webpack/get-client-config.js
@@ -8,7 +8,6 @@ const WebpackBar = require("webpackbar");
 const applyUserConfig = require("../utils/apply-user-config");
 const findAllNodeModules = require("../utils/find-all-node-modules");
 const getSassConfiguration = require("../utils/get-sass-options");
-const getJsTsRules = require("../utils/get-jsts-rules");
 const getWebpackCacheConfigFiles = require("../utils/get-webpack-cache-config-files");
 const resolveEntry = require("../utils/resolve-entry");
 const resolvePostCssConfig = require("../utils/resolve-postcss-config");
@@ -109,6 +108,24 @@ async function getClientConfig(args) {
       },
     ],
   });
+
+  const mwapEnvVariables = Object.entries(process.env).reduce(
+    (acc, [key, val]) => {
+      if (key.startsWith("MWAP_")) {
+        acc[key] = JSON.stringify(val);
+      }
+      return acc;
+    },
+    {}
+  );
+
+  if (Object.keys(mwapEnvVariables).length > 0) {
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        "process.env": mwapEnvVariables,
+      })
+    );
+  }
 
   if (isProd) {
     config.output.filename = "[name].[contenthash].js";

--- a/packages/mwap/package.json
+++ b/packages/mwap/package.json
@@ -35,6 +35,7 @@
     "autoprefixer": "10.2.5",
     "babel-loader": "8.2.2",
     "css-loader": "5.2.2",
+    "dotenv": "9.0.2",
     "esbuild-loader": "2.12.0",
     "fs-extra": "9.1.0",
     "inspectpack": "4.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,18 +1119,6 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@pmmmwh/react-refresh-webpack-plugin@0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
-  integrity sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==
-  dependencies:
-    ansi-html "^0.0.7"
-    error-stack-parser "^2.0.6"
-    html-entities "^1.2.1"
-    native-url "^0.2.6"
-    schema-utils "^2.6.5"
-    source-map "^0.7.3"
-
 "@polka/url@^1.0.0-next.9":
   version "1.0.0-next.12"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.12.tgz#431ec342a7195622f86688bbda82e3166ce8cb28"
@@ -1618,7 +1606,7 @@ ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-html@0.0.7, ansi-html@^0.0.7:
+ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
   integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
@@ -2542,6 +2530,11 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-9.0.2.tgz#dacc20160935a37dea6364aa1bef819fb9b6ab05"
+  integrity sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==
+
 duplexer@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
@@ -2616,13 +2609,6 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
-
-error-stack-parser@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.6.tgz#5a99a707bd7a4c58a797902d48d82803ede6aad8"
-  integrity sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==
-  dependencies:
-    stackframe "^1.1.1"
 
 es-abstract@^1.17.2, es-abstract@^1.18.0-next.2:
   version "1.18.0"
@@ -3297,7 +3283,7 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
-html-entities@^1.2.0, html-entities@^1.2.1:
+html-entities@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.4.0.tgz#cfbd1b01d2afaf9adca1b10ae7dffab98c71d2dc"
   integrity sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==
@@ -4209,13 +4195,6 @@ nanoid@^3.1.22:
   version "3.1.22"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
   integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
-
-native-url@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.2.6.tgz#ca1258f5ace169c716ff44eccbddb674e10399ae"
-  integrity sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==
-  dependencies:
-    querystring "^0.2.0"
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -5747,7 +5726,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3, source-map@~0.7.2:
+source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -5778,11 +5757,6 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
-
-stackframe@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
-  integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
 
 state-toggle@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
Added dotenv support.

How it works:
- `MWAP_` environment variables are inlined for client bundles
- No inlining for server bundles, instead the CLI loads your .env file at runtime (`mwap dev` and `mwap start`)

If you want additional environment variables to be inlined, simply add to your `mwap.config.js` something like the following:

```js
module.exports = {
  webpack(config, { isServer }, webpack) {
    if (!isServer) {
      config.plugins.push(new webpack.DefinePlugin({
        "process.env": {
          // just assign from process.env as your .env file will have been loaded for you already
          CUSTOM_VAR: process.env.CUSTOM_VAR,
        },
      }));
    }

    return config;
  }
};
```